### PR TITLE
Add PageXL suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12578,6 +12578,10 @@ pgfog.com
 // Submitted by Jason Kriss <jason@pagefronthq.com>
 pagefrontapp.com
 
+// PageXL : https://pagexl.com
+// Submitted by Yann Guichard <yann@pagexl.com>
+pagexl.com
+
 // .pl domains (grandfathered)
 art.pl
 gliwice.pl


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [ ] Run Syntax Checker (make test)

Description of Organization
====

PageXL is a SaaS for building responsive one-page sites.

Organization Website: https://pagexl.com

Reason for PSL Inclusion
====

PageXL allows users to publish their sites to the pagexl.com domain suffix (eg. mysitename.pagexl.com) so we're requesting inclusion in the PSL primarily to ensure cookie isolation/security for sites hosted on the platform.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
